### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ after this, you can use it just as
 there is no difference if you do nothing else.
 
 
-### change the value of the configureable items.
+### change the value of the configurable items.
 under easyconf.core, we also supply two function config and
-config-once to change the value of the configureable items.
+config-once to change the value of the configurable items.
 
 the only difference of these two functions is when you invoke
 conf-once two times with same conf-name , easyconf will throw a


### PR DESCRIPTION
@sukuizhang, I've corrected a typographical error in the documentation of the [easyconf](https://github.com/sukuizhang/easyconf) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
